### PR TITLE
Fixed compiler error: setFrameBufferLittleEndian is private in QScreen

### DIFF
--- a/libvncserverscreen_qws.cpp
+++ b/libvncserverscreen_qws.cpp
@@ -448,9 +448,6 @@ void LibVNCServerScreenPrivate::setDirty(const QRect& rect)
 bool LibVNCServerScreen::connect(const QString &displaySpec)
 {
     Q_UNUSED(displaySpec);
-#if Q_BYTE_ORDER == Q_BIG_ENDIAN
-    QScreen::setFrameBufferLittleEndian(false);
-#endif
 
     d = qgetenv("QWS_DEPTH").toInt();
     if (!d)


### PR DESCRIPTION
This call is not necessary as the attribute FrameBufferLittleEndian will be set in QScreen properly.